### PR TITLE
Corrected a breaking codeblock syntax error impacting readability

### DIFF
--- a/pages/docs/guides/customize-compose-and-traefik.mdx
+++ b/pages/docs/guides/customize-compose-and-traefik.mdx
@@ -27,6 +27,7 @@ Firstly we need to figure out what port traefik dashboard uses (which is 8080) a
 
 ```bash
 nano user-config/tipi-compose.yml
+```
 
 3. You should have this file structure:
 


### PR DESCRIPTION
Under the "[Create a custom docker compose file](https://runtipi.io/docs/guides/customize-compose-and-traefik#create-a-custom-docker-compose-file)" heading on the "[Customize main Docker compose and Traefik config](https://runtipi.io/docs/guides/customize-compose-and-traefik)" page, a three-character code block syntax error was corrected to improve broken readability of the page content.

If accepted, this directly closes #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added guidance on configuring the Traefik dashboard port using a code snippet in the customization guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->