### PR TITLE
Remove incorrect style from homepage image

### DIFF
--- a/components/pages/home.tsx
+++ b/components/pages/home.tsx
@@ -114,7 +114,7 @@ export default function Home() {
           </div>
           <div className="-ml-12 -mt-12 p-12 lg:sticky lg:top-4 lg:col-start-2 lg:row-span-2 lg:row-start-1 lg:overflow-hidden">
             <Image
-              className="w-[48rem] max-w-none rounded-xl bg-gray-900 shadow-xl ring-1 ring-gray-400/10 sm:w-[57rem]"
+              className="w-[48rem] max-w-none rounded-xl shadow-xl ring-1 ring-gray-400/10 sm:w-[57rem]"
               src={screenshot}
               alt="Screenshot of the Runtipi dashboard"
             />


### PR DESCRIPTION
The image on the homepage had a `bg-gray-900` class which caused a small visual bug when viewed in light mode. This PR removes it, as it seems useless anyway.

Before:
![Screenshot From 2024-12-18 21-54-26](https://github.com/user-attachments/assets/50a9da41-860b-4e63-8ee8-7bff6ff89d73)

After:
![Screenshot From 2024-12-18 21-54-32](https://github.com/user-attachments/assets/f6d3e34b-0546-474c-a6d4-0485bbe808f6)

(Notice the bottom left corner. The same happens to every corner)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the visual styling of the dashboard screenshot by modifying CSS classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->