### PR TITLE
Update auto-backup-apps for runtipi v4

### DIFF
--- a/src/content/docs/guides/auto-backup-apps.mdx
+++ b/src/content/docs/guides/auto-backup-apps.mdx
@@ -5,8 +5,6 @@ import { Steps, Callout } from "nextra/components";
 In this guide we will show you how to automate backing up all your apps every week, month or day using Runtipi's
 new backup feature.
 
-Thanks a lot to [Lancelot-Enguerrand](https://github.com/Lancelot-Enguerrand) for putting this script together.
-
 <Callout type="warning">
   This script requires Runtipi version `v4.0.0` or above.
 </Callout>
@@ -28,10 +26,10 @@ called `backup-apps.sh` and paste the following code:
  
 # Specify your runtipi base path
 runtipiPath=""
- 
+
 # Specify path to you backup reference list (optional)
 backupListPath=""
- 
+
 # Storage path for the Apps
 backupPath="$runtipiPath/backups"
 
@@ -52,8 +50,8 @@ userConfigsPath="$runtipiPath/user-config"
 # Define the temporary directory for the archive creation
 archiveCreatingWorkDir="/tmp"
 
-# App status - Set defaut value to started
-appOrginalStatus='started'
+# App status - Set default value to started
+appOriginalStatus='started'
 
 # Check for runtipi path value
 if [ -z "$runtipiPath" ]; then
@@ -65,7 +63,7 @@ else
     echo "Runtipi path not found : $runtipiPath"
     exit 1
 fi
- 
+
 # Default Parameters
 backupTypeDefaultValue='daily'
 stopAppDefaultValue='stop'
@@ -127,10 +125,10 @@ do
                 cd $runtipiPath
                 appStatusCheck=$(docker ps -f name=^/$app"_"$appStore -q)
                 if [ -z "$appStatusCheck" ]; then
-                    appOrginalStatus='stopped'
+                    appOriginalStatus='stopped'
                     echo "App $app is already stopped"
                 else
-                    appOrginalStatus='started'
+                    appOriginalStatus='started'
                     echo "Stopping $app"
                     ./runtipi-cli app stop $app:$appStore
                     sleep $sleepDuration
@@ -146,17 +144,17 @@ do
     
             # Use backup directory as archive file destination
             archiveCreatingWorkDir="$backupAppPath"
-    
+
             # Move to Working Directory for archive creation
             cd $archiveCreatingWorkDir
-    
+
             # Declare source and destination path for directories in archive
             declare -A app_paths=(
                 ["$appsPath/$appStore/$app"]="app"
                 ["$appsDataPath/$appStore/$app"]="app-data"
                 ["$userConfigsPath/$appStore/$app"]="user-config"
             )
-    
+
             echo "Preparing $app files"
             tempArchiveDir=$(mktemp -d)
             for src in "${!app_paths[@]}"; do
@@ -172,21 +170,21 @@ do
                     echo "Directory $src does not exist, skipped."
                 fi
             done
-    
+
             # Creating archive
             echo "Creating $app archive : $backupFileName"
             tar -czhf "$backupFileName" -C "$tempArchiveDir" .
             # Remove temporary Directory
             echo "Removing temporary files"
             rm -rf "$tempArchiveDir"
-    
+
             # Purge old backups of the same type
             cd "$backupAppPath"
             echo "Purging old $backupType backup for $app"
             ls -t | grep "$app-$backupType-" | tail -n +$((keepLast+1)) | xargs -r rm --
     
             # Restart the app if it was asked to be stopped
-            if [ "$stopApp" = 'stop' -a "$appOrginalStatus" = 'started' ]; then
+            if [ "$stopApp" = 'stop' -a "$appOriginalStatus" = 'started' ]; then
                 cd $runtipiPath
                 echo "Starting $app"
                 ./runtipi-cli app start $app:$appStore

--- a/src/content/docs/guides/auto-backup-apps.mdx
+++ b/src/content/docs/guides/auto-backup-apps.mdx
@@ -8,7 +8,7 @@ new backup feature.
 Thanks a lot to [Lancelot-Enguerrand](https://github.com/Lancelot-Enguerrand) for putting this script together.
 
 <Callout type="warning">
-  This script requires Runtipi verion `v4.0.0` or above.
+  This script requires Runtipi version `v4.0.0` or above.
 </Callout>
 
 ## Setup
@@ -28,6 +28,9 @@ called `backup-apps.sh` and paste the following code:
  
 # Specify your runtipi base path
 runtipiPath=""
+ 
+# Specify path to you backup reference list (optional)
+backupListPath=""
  
 # Storage path for the Apps
 backupPath="$runtipiPath/backups"
@@ -90,84 +93,107 @@ case "$backupType" in
         exit 2
         ;;
 esac
- 
+
+# Check Runtipi version
+runtipiVersion=$(cat $runtipiPath/VERSION)
+runtipiMajorVersion=$(echo $runtipiPath | cut -d. -f1 VERSION | sed 's/^v//')
+if [ "$major_version" -lt 4 ]; then
+    echo "Runtipi version is $runtipiVersion, this script require at least v4.0.0"
+    exit 4
+fi
+
 # Should Apps be stopped during backup
 stopApp="${2:-$stopAppDefaultValue}"
 
 # List all appstores
 for appStore in $(ls $appsPath)
 do
+    # Check optional apps reference list
+    refBackupList=$backupListPath
+    if [ -z "$refBackupList" ]; then
+        backupList=$(ls $appsPath/$appStore)
+    elif [ -f "$refBackupList" ]; then
+        backupList=$(cat $refBackupList)
+    else
+        echo "Invalid path for backup reference list file."
+        exit 3
+    fi
     # List all installed apps
-    for app in $(ls $appsPath/$appStore)
+    for app in $backupList
     do
-        # Stop the app if it was asked
-        if [ "$stopApp" = 'stop' ]; then
-            cd $runtipiPath
-            appStatusCheck=$(docker ps -f name=^/$app"_"$appStore -q)
-            if [ -z "$appStatusCheck" ]; then
-                appOrginalStatus='stopped'
-                echo "App $app is already stopped"
-            else
-                appOrginalStatus='started'
-                echo "Stopping $app"
-                ./runtipi-cli app stop $app:$appStore
+        if [ -d $appsPath/$appStore/$app ]; then
+            echo "Starting backup apps from $appStore appstore."
+            
+            # Stop the app if it was asked
+            if [ "$stopApp" = 'stop' ]; then
+                cd $runtipiPath
+                appStatusCheck=$(docker ps -f name=^/$app"_"$appStore -q)
+                if [ -z "$appStatusCheck" ]; then
+                    appOrginalStatus='stopped'
+                    echo "App $app is already stopped"
+                else
+                    appOrginalStatus='started'
+                    echo "Stopping $app"
+                    ./runtipi-cli app stop $app:$appStore
+                    sleep $sleepDuration
+                fi
+            fi
+
+            # Set destination app path
+            backupAppPath="$backupPath/$appStore/$app"
+            # Create destination directory if doesnt exist
+            if [ ! -d "$backupAppPath" ]; then mkdir -p "$backupAppPath"; fi
+            # Generate archive name
+            backupFileName="$app-$backupType-$(date '+%Y-%m-%d').tar.gz"
+    
+            # Use backup directory as archive file destination
+            archiveCreatingWorkDir="$backupAppPath"
+    
+            # Move to Working Directory for archive creation
+            cd $archiveCreatingWorkDir
+    
+            # Declare source and destination path for directories in archive
+            declare -A app_paths=(
+                ["$appsPath/$appStore/$app"]="app"
+                ["$appsDataPath/$appStore/$app"]="app-data"
+                ["$userConfigsPath/$appStore/$app"]="user-config"
+            )
+    
+            echo "Preparing $app files"
+            tempArchiveDir=$(mktemp -d)
+            for src in "${!app_paths[@]}"; do
+                dest="$tempArchiveDir/${app_paths[$src]}"
+                echo $dest
+                # Ensure the directory exists
+                if [ -d "$src" ]; then
+                    # Create symbolic link for each directory
+                    ln -s "$src" "$dest"
+                elif [ $src = "$userConfigsPath/$appStore/$app" ]; then
+                    : # echo "No user config for $app"
+                else
+                    echo "Directory $src does not exist, skipped."
+                fi
+            done
+    
+            # Creating archive
+            echo "Creating $app archive : $backupFileName"
+            tar -czhf "$backupFileName" -C "$tempArchiveDir" .
+            # Remove temporary Directory
+            echo "Removing temporary files"
+            rm -rf "$tempArchiveDir"
+    
+            # Purge old backups of the same type
+            cd "$backupAppPath"
+            echo "Purging old $backupType backup for $app"
+            ls -t | grep "$app-$backupType-" | tail -n +$((keepLast+1)) | xargs -r rm --
+    
+            # Restart the app if it was asked to be stopped
+            if [ "$stopApp" = 'stop' -a "$appOrginalStatus" = 'started' ]; then
+                cd $runtipiPath
+                echo "Starting $app"
+                ./runtipi-cli app start $app:$appStore
                 sleep $sleepDuration
             fi
-        fi
-
-        echo "Preparing $app backup"
-        # Set destination app path
-        backupAppPath="$backupPath/$appStore/$app"
-        # Create destination directory if doesnt exist
-        if [ ! -d "$backupAppPath" ]; then mkdir -p "$backupAppPath"; fi
-        # Generate archive name
-        backupFileName="$app-$backupType-$(date '+%Y-%m-%d').tar.gz"
-
-        # Set archive archive destination to the backup directory
-        archiveCreatingWorkDir="$backupAppPath"
-
-        # Move to Working Directory for archive creation
-        cd $archiveCreatingWorkDir
-
-        # Declare source and destination path for directories in archive
-        declare -A app_paths=(
-            ["$appsPath/$appStore/$app"]="app"
-            ["$appsDataPath/$appStore/$app"]="app-data"
-            ["$userConfigsPath/$appStore/$app"]="user-config"
-        )
-
-        echo "Preparing $app files"
-        tempArchiveDir=$(mktemp -d)
-        for src in "${!app_paths[@]}"; do
-            dest="$tempArchiveDir/${app_paths[$src]}"
-            echo $dest
-            # Ensure the directory exists
-            if [ -d "$src" ]; then
-                # Create symbolic link for each directory
-                ln -s "$src" "$dest"
-            else
-                echo "Directory $src does not exist, skipped."
-            fi
-        done
-
-        # Creating archive
-        echo "Creating $app archive : $backupFileName"
-        tar -czhf "$backupFileName" -C "$tempArchiveDir" .
-        # Remove temporary Directory
-        echo "Removing temporary files"
-        rm -rf "$tempArchiveDir"
-
-        # Purge old backups of the same type
-        cd "$backupAppPath"
-        echo "Purging old $backupType backup for $app"
-        ls -t | grep "$app-$backupType-" | tail -n +$((keepLast+1)) | xargs -r rm --
-
-        # Restart the app if it was asked to be stopped
-        if [ "$stopApp" = 'stop' -a "$appOrginalStatus" = 'started' ]; then
-            cd $runtipiPath
-            echo "Starting $app"
-            ./runtipi-cli app start $app:$appStore
-            sleep $sleepDuration
         fi
     done
 done
@@ -175,10 +201,10 @@ done
 
 The script takes 3 arguments:
 
-| Accepted Values            | Description                                                                                                        | Default | Required |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
-| `monthly`,`weekly`,`daily` | Set the name of the final backup, for example if you use `daily` the backup name will be `myapp-daily-date.tar.gz` | `daily` | no       |
-| `stop`,`ignore`            | Stop the app before backing up or backup anyway.                                                                   | `stop`  | no       |
+| Accepted Values                      | Description                                                                                                        | Default | Required |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
+| `yearly`, `monthly`,`weekly`,`daily` | Set the name of the final backup, for example if you use `daily` the backup name will be `myapp-daily-date.tar.gz` | `daily` | no       |
+| `stop`,`ignore`                      | Stop the app before backing up or backup anyway.                                                                   | `stop`  | no       |
 
 The script also allows you to change for how long you want to keep backups, this can be configured by chaning the following values:
 
@@ -195,6 +221,9 @@ Each number indicates the retention period for the backup, specifying how many c
   Make sure to change the `runtipiPath` in the script to point to your actual
   Runtipi path.
 </Callout>
+
+Optionnaly, you can restrict the apps to backup with a list:
+Edit the `backupListPath` in the script with a path to a file describing what apps you want to backup, each app id in a new line.
 
 ### Make the script executable
 

--- a/src/content/docs/guides/auto-backup-apps.mdx
+++ b/src/content/docs/guides/auto-backup-apps.mdx
@@ -24,7 +24,7 @@ called `backup-apps.sh` and paste the following code:
 #!/bin/bash
 #
 # Usage: ./backup_runtipi_apps.sh [daily|weekly|monthly|yearly] [stop|ignore]
-# Default parameters are daily stop
+# Default parameters are "daily stop"
  
 # Specify your runtipi base path
 runtipiPath=""
@@ -206,7 +206,7 @@ The script takes 3 arguments:
 | `monthly`,`weekly`,`daily` | Set the name of the final backup, for example if you use `daily` the backup name will be `myapp-daily-date.tar.gz` | `daily` | no       |
 | `stop`,`ignore`            | Stop the app before backing up or backup anyway.                                                                   | `stop`  | no       |
 
-### Manage retention
+#### Manage retention
 The script allows you to change for how long you want to keep backups, this can be configured by chaning the following values:
 
 ```bash
@@ -217,7 +217,7 @@ monthlyRetention=3
 
 Each number indicates the retention period for the backup, specifying how many cycles it should be kept before deletion. For instance, a daily backup will be deleted after 3 days, while a monthly backup will be deleted after 3 months etc.
 
-### Apps selection
+#### Apps selection
 You can restrict the apps to backup with a list:
 - In the script, edit the `backupListPath` 
 - Enter the path to a file describing what apps you want to backup, each app id in a new line.

--- a/src/content/docs/guides/auto-backup-apps.mdx
+++ b/src/content/docs/guides/auto-backup-apps.mdx
@@ -206,7 +206,8 @@ The script takes 3 arguments:
 | `monthly`,`weekly`,`daily` | Set the name of the final backup, for example if you use `daily` the backup name will be `myapp-daily-date.tar.gz` | `daily` | no       |
 | `stop`,`ignore`            | Stop the app before backing up or backup anyway.                                                                   | `stop`  | no       |
 
-The script also allows you to change for how long you want to keep backups, this can be configured by chaning the following values:
+### Manage retention
+The script allows you to change for how long you want to keep backups, this can be configured by chaning the following values:
 
 ```bash
 dailyRetention=3
@@ -216,13 +217,15 @@ monthlyRetention=3
 
 Each number indicates the retention period for the backup, specifying how many cycles it should be kept before deletion. For instance, a daily backup will be deleted after 3 days, while a monthly backup will be deleted after 3 months etc.
 
+### Apps selection
+You can restrict the apps to backup with a list:
+- In the script, edit the `backupListPath` 
+- Enter the path to a file describing what apps you want to backup, each app id in a new line.
+
 <Callout type="info">
   Make sure to change the `runtipiPath` in the script to point to your actual
   Runtipi path.
 </Callout>
-
-Optionnaly, you can restrict the apps to backup with a list:
-Edit the `backupListPath` in the script with a path to a file describing what apps you want to backup, each app id in a new line.
 
 ### Make the script executable
 

--- a/src/content/docs/guides/auto-backup-apps.mdx
+++ b/src/content/docs/guides/auto-backup-apps.mdx
@@ -23,7 +23,7 @@ called `backup-apps.sh` and paste the following code:
 ```bash
 #!/bin/bash
 #
-# Usage: ./backup_runtipi_apps.sh [daily|weekly|monthly|yearly] [stop|ignore]
+# Usage: ./backup-apps.sh [daily|weekly|monthly|yearly] [stop|ignore]
 # Default parameters are "daily stop"
  
 # Specify your runtipi base path
@@ -58,13 +58,11 @@ appOrginalStatus='started'
 # Check for runtipi path value
 if [ -z "$runtipiPath" ]; then
     echo "Runtipi path not specified"
-    echo "Edit path, line 9 in $0"
     exit 1
 elif [ -d "$runtipiPath" ]; then
     echo "Runtipi path : $runtipiPath"
 else
     echo "Runtipi path not found : $runtipiPath"
-    echo "Edit path, line 9 in $0"
     exit 1
 fi
  
@@ -96,7 +94,7 @@ esac
 
 # Check Runtipi version
 runtipiVersion=$(cat $runtipiPath/VERSION)
-runtipiMajorVersion=$(echo $runtipiPath | cut -d. -f1 VERSION | sed 's/^v//')
+runtipiMajorVersion=$(echo $runtipiVersion | cut -d. -f1 VERSION | sed 's/^v//')
 if [ "$major_version" -lt 4 ]; then
     echo "Runtipi version is $runtipiVersion, this script require at least v4.0.0"
     exit 4

--- a/src/content/docs/guides/auto-backup-apps.mdx
+++ b/src/content/docs/guides/auto-backup-apps.mdx
@@ -201,10 +201,10 @@ done
 
 The script takes 3 arguments:
 
-| Accepted Values                      | Description                                                                                                        | Default | Required |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
-| `yearly`, `monthly`,`weekly`,`daily` | Set the name of the final backup, for example if you use `daily` the backup name will be `myapp-daily-date.tar.gz` | `daily` | no       |
-| `stop`,`ignore`                      | Stop the app before backing up or backup anyway.                                                                   | `stop`  | no       |
+| Accepted Values            | Description                                                                                                        | Default | Required |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
+| `monthly`,`weekly`,`daily` | Set the name of the final backup, for example if you use `daily` the backup name will be `myapp-daily-date.tar.gz` | `daily` | no       |
+| `stop`,`ignore`            | Stop the app before backing up or backup anyway.                                                                   | `stop`  | no       |
 
 The script also allows you to change for how long you want to keep backups, this can be configured by chaning the following values:
 
@@ -212,7 +212,6 @@ The script also allows you to change for how long you want to keep backups, this
 dailyRetention=3
 weeklyRetention=3
 monthlyRetention=3
-yearlyRetention=3
 ```
 
 Each number indicates the retention period for the backup, specifying how many cycles it should be kept before deletion. For instance, a daily backup will be deleted after 3 days, while a monthly backup will be deleted after 3 months etc.

--- a/src/content/docs/guides/auto-backup-apps.mdx
+++ b/src/content/docs/guides/auto-backup-apps.mdx
@@ -8,7 +8,7 @@ new backup feature.
 Thanks a lot to [Lancelot-Enguerrand](https://github.com/Lancelot-Enguerrand) for putting this script together.
 
 <Callout type="warning">
-  This script requires Runtipi verion `v3.5.0` or above.
+  This script requires Runtipi verion `v4.0.0` or above.
 </Callout>
 
 ## Setup
@@ -22,48 +22,52 @@ called `backup-apps.sh` and paste the following code:
 
 ```bash
 #!/bin/bash
-# Usage: ./backup_runtipi_apps.sh [daily|weekly|monthly] [stop|ignore] [path/to/BackupListFile]
+#
+# Usage: ./backup_runtipi_apps.sh [daily|weekly|monthly|yearly] [stop|ignore]
 # Default parameters are daily stop
+ 
+# Specify your runtipi base path
+runtipiPath=""
+ 
+# Storage path for the Apps
+backupPath="$runtipiPath/backups"
 
-# Specify your Runtipi base path
-tipiPath=""
-
-# Storage path for the Apps (each app have a folder inside)
-backupPath="$tipiPath/backups"
-
-# Specify backup retention - Indicate number of backup file to keep for each schedule
+# Specify backup retention - Number of backup file to keep for each schedule
 dailyRetention=3
 weeklyRetention=3
 monthlyRetention=3
+yearlyRetention=3
 
-# Default Runtipi paths
-appsDataPath="$tipiPath/app-data"
-appsPath="$tipiPath/apps"
-userConfigsPath="$tipiPath/user-config"
+# Sleep Duration - How many seconds to wait after starting/stopping an apps
+sleepDuration=10
+
+# Default runtipi paths
+appsDataPath="$runtipiPath/app-data"
+appsPath="$runtipiPath/apps"
+userConfigsPath="$runtipiPath/user-config"
 
 # Define the temporary directory for the archive creation
 archiveCreatingWorkDir="/tmp"
 
-# App status - Set defaut value to prevent bug - do not touch
+# App status - Set defaut value to started
 appOrginalStatus='started'
 
-# Check for Runtipi path value
-if [ -z "$tipiPath" ]; then
+# Check for runtipi path value
+if [ -z "$runtipiPath" ]; then
     echo "Runtipi path not specified"
-    echo "Edit path, line 6 in $0"
+    echo "Edit path, line 9 in $0"
     exit 1
-elif [ -d "$tipiPath" ]; then
-    echo "Runtipi path : $tipiPath"
+elif [ -d "$runtipiPath" ]; then
+    echo "Runtipi path : $runtipiPath"
 else
-    echo "Runtipi path not found : $tipiPath"
-    echo "Edit path, line 6 in $0"
+    echo "Runtipi path not found : $runtipiPath"
+    echo "Edit path, line 9 in $0"
     exit 1
 fi
-
+ 
 # Default Parameters
 backupTypeDefaultValue='daily'
 stopAppDefaultValue='stop'
-backupListDefaultValue=$(ls $appsDataPath)
 
 # Define retention policy
 backupType="${1:-$backupTypeDefaultValue}"
@@ -78,104 +82,92 @@ case "$backupType" in
     monthly)
         keepLast=$monthlyRetention
         ;;
+    yearly)
+        keepLast=$yearlyRetention
+        ;;
     *)
-        echo "Invalid backup type specified. Use 'daily', 'weekly' or 'monthly'."
+        echo "Invalid backup type specified. Use 'daily', 'weekly', 'monthly' or 'yearly'."
         exit 2
         ;;
 esac
-
+ 
 # Should Apps be stopped during backup
 stopApp="${2:-$stopAppDefaultValue}"
 
-# Should Apps be stopped during backup
-refBackupList=$3
-if [ -z "$refBackupList" ]; then
-    backupList=$backupListDefaultValue
-elif [ -f "$refBackupList" ]; then
-    backupList=$(cat $refBackupList)
-else
-    echo "Invalid path for backup list reference file."
-    exit 3
-fi
-
-# List all installed apps
-for app in $(ls $appsPath)
+# List all appstores
+for appStore in $(ls $appsPath)
 do
-    # List all apps in backup reference list
-    for element in $backupList
+    # List all installed apps
+    for app in $(ls $appsPath/$appStore)
     do
-        # Check if app is installed
-        if [ "$app" = "$element" ]; then
-            # Stop the app if it was asked
-            if [ "$stopApp" = 'stop' ]; then
-                cd $tipiPath
-                appStatusCheck=$(docker ps -f name=^/$app$ -q)
-                if [ -z "$appStatusCheck" ]; then
-                    appOrginalStatus='stopped'
-                    echo "App $app is already stopped"
-                else
-                    appOrginalStatus='started'
-                    echo "Stopping $app"
-                    ./runtipi-cli app stop $app
-                fi
+        # Stop the app if it was asked
+        if [ "$stopApp" = 'stop' ]; then
+            cd $runtipiPath
+            appStatusCheck=$(docker ps -f name=^/$app"_"$appStore -q)
+            if [ -z "$appStatusCheck" ]; then
+                appOrginalStatus='stopped'
+                echo "App $app is already stopped"
+            else
+                appOrginalStatus='started'
+                echo "Stopping $app"
+                ./runtipi-cli app stop $app:$appStore
+                sleep $sleepDuration
             fi
+        fi
 
-            echo "Preparing $app backup"
-            # Set destination app path
-            backupAppPath="$backupPath/$app"
-            # Create destination directory if doesnt exist
-            if [ ! -d "$backupAppPath" ]; then mkdir -p "$backupAppPath"; fi
-            # Generate archive name
-            backupFileName="$app-$backupType-$(date '+%Y-%m-%d').tar.gz"
+        echo "Preparing $app backup"
+        # Set destination app path
+        backupAppPath="$backupPath/$appStore/$app"
+        # Create destination directory if doesnt exist
+        if [ ! -d "$backupAppPath" ]; then mkdir -p "$backupAppPath"; fi
+        # Generate archive name
+        backupFileName="$app-$backupType-$(date '+%Y-%m-%d').tar.gz"
 
-            # Uncomment next line if you want the archive to be created directly in backup destination
-            ## archiveCreatingWorkDir="$backupAppPath"
+        # Set archive archive destination to the backup directory
+        archiveCreatingWorkDir="$backupAppPath"
 
-            # Move to Working Directory for archive creation
-            cd $archiveCreatingWorkDir
+        # Move to Working Directory for archive creation
+        cd $archiveCreatingWorkDir
 
-            # Declare source and destination path for directories in archive
-            declare -A app_paths=(
-                ["$appsPath/$app"]="app"
-                ["$appsDataPath/$app"]="app-data"
-                ["$userConfigsPath/$app"]="user-config"
-            )
+        # Declare source and destination path for directories in archive
+        declare -A app_paths=(
+            ["$appsPath/$appStore/$app"]="app"
+            ["$appsDataPath/$appStore/$app"]="app-data"
+            ["$userConfigsPath/$appStore/$app"]="user-config"
+        )
 
-            echo "Preparing $app files"
-            tempArchiveDir=$(mktemp -d)
-            for src in "${!app_paths[@]}"; do
-                dest="$tempArchiveDir/${app_paths[$src]}"
-                echo $dest
-                # Ensure the directory exists
-                if [ -d "$src" ]; then
-                    # Create symbolic link for each directory
-                    ln -s "$src" "$dest"
-                else
-                    echo "Directory $src does not exist, skipped."
-                fi
-            done
-
-            # Creating archive
-            echo "Creating $app archive : $backupFileName"
-            tar -czhf "$backupFileName" -C "$tempArchiveDir" .
-            # Move archive to Backup storage
-            echo "Moving $backupFileName to $backupAppPath"
-            mv "$backupFileName" "$backupAppPath"
-            # Remove temporary Directory
-            echo "Removing temporary files"
-            rm -rf "$tempArchiveDir"
-
-            # Purge old backups of the same type
-            cd "$backupAppPath"
-            echo "Purging old $backupType backup for $app"
-            ls -t | grep "$app-$backupType-" | tail -n +$((keepLast+1)) | xargs -r rm --
-
-            # Restart the app if it was asked to be stopped
-            if [ "$stopApp" = 'stop' -a "$appOrginalStatus" = 'started' ]; then
-                cd $tipiPath
-                echo "Starting $app"
-                ./runtipi-cli app start $app
+        echo "Preparing $app files"
+        tempArchiveDir=$(mktemp -d)
+        for src in "${!app_paths[@]}"; do
+            dest="$tempArchiveDir/${app_paths[$src]}"
+            echo $dest
+            # Ensure the directory exists
+            if [ -d "$src" ]; then
+                # Create symbolic link for each directory
+                ln -s "$src" "$dest"
+            else
+                echo "Directory $src does not exist, skipped."
             fi
+        done
+
+        # Creating archive
+        echo "Creating $app archive : $backupFileName"
+        tar -czhf "$backupFileName" -C "$tempArchiveDir" .
+        # Remove temporary Directory
+        echo "Removing temporary files"
+        rm -rf "$tempArchiveDir"
+
+        # Purge old backups of the same type
+        cd "$backupAppPath"
+        echo "Purging old $backupType backup for $app"
+        ls -t | grep "$app-$backupType-" | tail -n +$((keepLast+1)) | xargs -r rm --
+
+        # Restart the app if it was asked to be stopped
+        if [ "$stopApp" = 'stop' -a "$appOrginalStatus" = 'started' ]; then
+            cd $runtipiPath
+            echo "Starting $app"
+            ./runtipi-cli app start $app:$appStore
+            sleep $sleepDuration
         fi
     done
 done
@@ -187,7 +179,6 @@ The script takes 3 arguments:
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- | -------- |
 | `monthly`,`weekly`,`daily` | Set the name of the final backup, for example if you use `daily` the backup name will be `myapp-daily-date.tar.gz` | `daily` | no       |
 | `stop`,`ignore`            | Stop the app before backing up or backup anyway.                                                                   | `stop`  | no       |
-| `path`                     | Specify a path to a file describing what apps you want to backup, each app id in a new line.                       | `none`  | no       |
 
 The script also allows you to change for how long you want to keep backups, this can be configured by chaning the following values:
 
@@ -195,12 +186,13 @@ The script also allows you to change for how long you want to keep backups, this
 dailyRetention=3
 weeklyRetention=3
 monthlyRetention=3
+yearlyRetention=3
 ```
 
 Each number indicates the retention period for the backup, specifying how many cycles it should be kept before deletion. For instance, a daily backup will be deleted after 3 days, while a monthly backup will be deleted after 3 months etc.
 
 <Callout type="info">
-  Make sure to change the `tipiPath` in the script to point to your actual
+  Make sure to change the `runtipiPath` in the script to point to your actual
   Runtipi path.
 </Callout>
 
@@ -226,10 +218,17 @@ Now it's time to add our script to crontab. We firstly need to open the crontab 
 sudo crontab -e
 ```
 
-Then we can add our crontab line, in this example we will backup our apps every Monday at 10 p.m.
+Then we can add our crontab line, in this example we will backup our apps every day of the week at 2 a.m and the first day of the month at 3 p.m.
 
 ```bash
-0 22 * * 0 /path/to/runtipi/scripts/backup-apps.sh weekly
+# Every day from Tuesday to Sunday at 2 AM - daily
+0 2 * * 2-7 /path/to/runtipi/scripts/backup_runtipi_apps.sh daily
+
+# Every Monday at 2 AM - weekly
+0 2 * * 1 /path/to/runtipi/scripts/backup_runtipi_apps.sh weekly
+
+# Every 1st day of the month at 3 AM - monthly
+0 3 1 * * /path/to/runtipi/scripts/backup_runtipi_apps.sh monthly
 ```
 
 After adding our line we can save and exit and that's it! Now your apps will backup automatically!

--- a/src/content/docs/guides/auto-backup-apps.mdx
+++ b/src/content/docs/guides/auto-backup-apps.mdx
@@ -117,7 +117,7 @@ do
     # List all installed apps
     for app in $backupList
     do
-        if [ -d $appsPath/$appStore/$app ]; then
+        if [ -d "$appsPath/$appStore/$app" ]; then
             echo "Starting backup apps from $appStore appstore."
             
             # Stop the app if it was asked


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated backup guide to require Runtipi version 4.0.0 or above.
  - Added support and instructions for a new "yearly" backup type and retention configuration.
  - Clarified usage for specifying backup app lists and updated variable names for clarity.
  - Expanded crontab scheduling examples for daily, weekly, monthly, and yearly backups.
  - Improved instructions and text consistency throughout the guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->