### PR TITLE
Small improvements

### DIFF
--- a/src/content/docs/apps-available.mdx
+++ b/src/content/docs/apps-available.mdx
@@ -3,6 +3,8 @@ import { ArrowRightIcon, PlusCircleIcon, WrenchIcon } from "@heroicons/react/24/
 
 # Apps available
 
-Runtipi has a wide range of selfhosted apps you can install on your server. You can find them all in the [app store repository](https://github.com/runtipi/runtipi-appstore) and make requests for new apps there.
+Runtipi has a wide range of selfhosted apps you can install on your server. You can find them all in the [app store repository](https://github.com/runtipi/runtipi-appstore).
+If you can't find what you're looking for, there are many [community app stores](https://github.com/runtipi/runtipi/discussions/categories/app-stores)
+to explore.
 
 <AppsList />

--- a/src/content/docs/introduction.mdx
+++ b/src/content/docs/introduction.mdx
@@ -18,7 +18,8 @@ Whether you are an experienced developer or a beginner, Runtipi allows you to fo
 The project's philosophy is to democratize the ability to self-host services by providing a simple, yet powerful tool that enables everyone to host their own services.
 
 Runtipi comes with an extensive library of services in the [App Store](/docs/apps-available).
-If you cannot find what you need, you can easily create custom services through the web interface.
+If you cannot find what you need, you can easily create custom services through the web interface, or explore the
+[community App Stores](https://github.com/runtipi/runtipi/discussions/categories/app-stores).
 
 ## Get Started
 

--- a/src/content/docs/learn/troubleshooting.mdx
+++ b/src/content/docs/learn/troubleshooting.mdx
@@ -49,7 +49,7 @@ A: Generally no, but check the [release notes](/docs/reference/release-notes) fo
 
 A: Make sure you're running with sudo:
 ```bash
-sudo curl -L https://setup.runtipi.io | sudo bash
+curl -L https://setup.runtipi.io | sudo bash
 ```
 
 ---
@@ -62,7 +62,7 @@ A: Yes, just cd to that directory before running the install script.
 
 **Q: Can I install apps that aren't in the App Store?**
 
-A: You can create your own app through the web UI or use one of the [community app store](https://github.com/runtipi/runtipi/discussions/categories/app-stores) repositories
+A: You can create your own app through the web UI or use one of the [community app store](https://github.com/runtipi/runtipi/discussions/categories/app-stores) repositories.
 
 ---
 
@@ -74,7 +74,7 @@ A: All app data is in `app-data/[store-slug]/[app-name]/` in your Runtipi direct
 
 ### Networking questions
 
-**Q: Can I use Runtipi behind another reverse proxy like NPM?**
+**Q: Can I use Runtipi behind another reverse proxy like Nginx Proxy Manager?**
 
 A: Yes, but it's complex. Runtipi uses Traefik internally. You'd need to configure your external proxy to forward to Runtipi's Traefik and customize your settings to free up ports.
 


### PR DESCRIPTION
While reading through the docs, it mentioned that you could still request new apps for the official App Store. I added some changes to clarify you could explore community App Stores instead.

I also made some minor other changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated app discovery documentation with references to community app stores for expanded app selection
  * Added guidance on exploring community app stores as an alternative when services aren't available in the built-in App Store
  * Corrected installation command syntax in troubleshooting section
  * Clarified reverse proxy configuration terminology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->