### PR TITLE
docs: add section about local build

### DIFF
--- a/src/content/docs/developers/creating-apps.mdx
+++ b/src/content/docs/developers/creating-apps.mdx
@@ -16,6 +16,7 @@ A step-by-step guide to build, test, and submit an app.
 - Start from a minimal `docker-compose.yml` for your service(s)
 - Use `x-runtipi.is_main` and `x-runtipi.internal_port` for the main web service instead of writing Traefik labels by hand
 - Map persistent data to a volume
+- If you need to build an image locally, use Docker Compose `build` with an explicit local `image` tag and `pull_policy: build`
 
 ## 3) Define `config.json`
 

--- a/src/content/docs/guides/custom-settings.mdx
+++ b/src/content/docs/guides/custom-settings.mdx
@@ -34,6 +34,7 @@ You can change the default settings by creating a `settings.json` file in `runti
 | `allowErrorMonitoring`        | Whether the app will send anonymous crash reports to the Runtipi developers | `boolean` | `false`                                       |
 | `allowAutoThemes`             | Enables thematically changing the dashboard based on the time of the year   | `boolean` | `true`                                        |
 | `persistTraefikConfig`        | Do not replace the Traefik config on every restart of Runtipi               | `boolean` | `false`                                       |
+| `trustedProxyIps`             | Comma-separated proxy IPs or CIDRs Traefik should trust for forwarded headers | `string`  | empty                                         |
 | `eventsTimeout`               | The time in minutes to wait for an action to complete before timing out     | `integer` | `5`                                           |
 | `advancedSettings`            | Show advanced settings in the dashboard                                     | `boolean` | `false`                                       |
 | `forwardAuthUrl`              | Override the Traefik forward-auth endpoint                                  | `string`  | `http://runtipi:3000/api/auth/traefik`        |

--- a/src/content/docs/guides/dynamic-compose-guide.mdx
+++ b/src/content/docs/guides/dynamic-compose-guide.mdx
@@ -58,6 +58,40 @@ x-runtipi:
   schema_version: 2
 ```
 
+### Build a local image
+
+If your app needs to build its own Docker image, use standard Docker Compose
+`build` syntax together with a local image tag and `pull_policy: build`:
+
+```yaml
+services:
+  myapp:
+    image: myapp:local
+    pull_policy: build
+    build:
+      context: ./data
+    x-runtipi:
+      is_main: true
+      internal_port: 80
+
+x-runtipi:
+  schema_version: 2
+```
+
+The `build.context` path is resolved by Docker Compose relative to the app's
+`docker-compose.yml` file. For example:
+
+```text
+myapp/
+  docker-compose.yml
+  data/
+    Dockerfile
+    src/
+```
+
+Keep the `image` field when using local builds. The local tag gives Docker
+Compose and Runtipi a stable name for the built image.
+
 ### Expose the web UI
 
 If your service exposes a web UI, mark it as the main service with its port. Runtipi will automatically configure Traefik routing for this service:

--- a/src/content/docs/guides/expose-apps-with-cloudflare-tunnels.mdx
+++ b/src/content/docs/guides/expose-apps-with-cloudflare-tunnels.mdx
@@ -73,6 +73,62 @@ You should now see the tunnel running in the dashboard.
 Alternatively you can use the Cloudflare Tunnels app in the app store. Just install it, open the dashboard and copy paste the `cloudflared`
 command that Cloudflare gave you (make sure to remove the `sudo` command).
 
+### Trust the tunnel proxy headers
+
+When Runtipi is behind Cloudflare Tunnel, Traefik must trust the `cloudflared` connector before it accepts forwarded headers like `X-Forwarded-Host` and `X-Forwarded-Proto`. If Traefik does not trust the connector, actions such as starting, stopping, or updating apps from the dashboard can fail with `Invalid request origin`.
+
+Add the connector IP address or CIDR to `runtipi/state/settings.json`:
+
+```json
+{
+  "trustedProxyIps": "172.18.0.5/32"
+}
+```
+
+Then restart Runtipi.
+
+<Callout type="warning">
+  Use the IP address of the proxy or tunnel connector as seen by Traefik, not
+  your browser IP and not Cloudflare's public edge IP ranges.
+</Callout>
+
+If `cloudflared` is running as a Docker container on the `runtipi_tipi_main_network`, list the containers on that network:
+
+```bash
+docker ps --filter network=runtipi_tipi_main_network --format "table {{.Names}}\t{{.Networks}}"
+```
+
+Then inspect the connector container:
+
+```bash
+docker inspect -f '{{with index .NetworkSettings.Networks "runtipi_tipi_main_network"}}{{.IPAddress}}{{end}}' <cloudflared-container-name>
+```
+
+If the connector is not running as a Docker container on the Runtipi network, use Traefik access logs to find the source address Traefik receives:
+
+1. Open `runtipi/traefik/traefik.yml`.
+2. Add JSON access logs:
+
+```yaml
+accessLog:
+  format: json
+```
+
+3. Restart only Traefik:
+
+```bash
+docker restart runtipi-reverse-proxy
+```
+
+4. Reproduce the `Invalid request origin` error once.
+5. Check the Traefik logs and look for `ClientAddr`:
+
+```bash
+docker logs runtipi-reverse-proxy --tail 100
+```
+
+Use the IP part of `ClientAddr` as the value for `trustedProxyIps`, usually with a `/32` suffix for a single IPv4 address.
+
 ### Add a Public hostname to your tunnel
 
 Select your newly created tunnel, **configure** and click on the **Public hostname** tab.

--- a/src/content/docs/reference/dynamic-compose.mdx
+++ b/src/content/docs/reference/dynamic-compose.mdx
@@ -115,6 +115,30 @@ services:
 
 You can reference variables defined in the app's `config.json` form fields using `${VARIABLE_NAME}`.
 
+### Local Image Builds
+
+Runtipi supports Docker Compose local builds when the service keeps an explicit
+local image tag:
+
+```yaml
+services:
+  app:
+    image: app:local
+    pull_policy: build
+    build:
+      context: ./data
+    x-runtipi:
+      is_main: true
+      internal_port: 80
+
+x-runtipi:
+  schema_version: 2
+```
+
+`build.context` is resolved relative to the app's `docker-compose.yml` file.
+Use `pull_policy: build` when you want Docker Compose to build the local image
+instead of trying to pull it from a registry.
+
 ### Ports
 
 Runtipi automatically maps `${APP_PORT}` to the main service's `internal_port` — you do not need to define this mapping yourself. For **additional** ports beyond the main one, expose them directly:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for building local Docker images via Compose during app scaffolding, including examples and pull-policy behavior
  * Clarified how build context is resolved for Compose-based app configs
  * Added a new setting for trusted proxy IPs for Traefik
  * Added troubleshooting and configuration steps for deployments behind Cloudflare Tunnel, including methods to identify connector IPs and required restart steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->