### PR TITLE
docs: clarify RUNTIPI_APP_ID limitations in user-config

### DIFF
--- a/src/content/docs/reference/dynamic-compose.mdx
+++ b/src/content/docs/reference/dynamic-compose.mdx
@@ -335,6 +335,10 @@ Use `{{RUNTIPI_APP_ID}}` wherever you need the full app identifier. Runtipi's te
   Runtipi's template engine and will remain as a literal string.
 </Callout>
 
+<Callout type="warning">
+  Do not use `${RUNTIPI_APP_ID}` in your `user-config` files — it is only resolved by Runtipi’s template engine during custom app creation.
+</Callout>
+
 ### Example: Security Header Middlewares
 
 ```yaml


### PR DESCRIPTION
Add a warning to not use RUNTIPI_APP_ID placeholder in a user-config file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on custom app configuration to clarify which template variables must not be used in user-configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/runtipi/runtipi-docs/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->